### PR TITLE
Ruby 2.1.0: Digest::Digest is deprecated; use Digest

### DIFF
--- a/lib/signauth/signer.rb
+++ b/lib/signauth/signer.rb
@@ -11,7 +11,7 @@ module Signauth
 
     def hmac(key, value, algorithm = 'HMAC-SHA-256')
       digest = digest_name(algorithm)
-      OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new(digest), key, value)
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new(digest), key, value)
     end
 
     def slow_string_comparison(given, computed)


### PR DESCRIPTION
Since Ruby 2.1.0 use of OpenSSL::Digest::Digest is deprecated.
Use OpenSSL::Digest instead.
